### PR TITLE
Fix: Allow None for ImageField default in OCR node

### DIFF
--- a/ocr_node.py
+++ b/ocr_node.py
@@ -24,7 +24,7 @@ pytesseract.pytesseract.tesseract_cmd = r'C:\Program Files\Tesseract-OCR\tessera
 class ImageToTextInvocation(BaseInvocation):
     """Extract text from an image using OCR."""
 
-    image: ImageField = InputField(default=None, description="The image for text extraction")
+    image: Optional[ImageField] = InputField(default=None, description="The image for text extraction")
 
     def invoke(self, context: InvocationContext) -> StringOutput:
         # Retrieve the PIL image


### PR DESCRIPTION
Changed the type annotation for the `image` field in `ImageToTextInvocation` from `ImageField` to `Optional[ImageField]`.

This resolves a Pydantic ValidationError that occurred during node loading because `default=None` was provided for a field that was not explicitly marked as Optional. The `ImageField` type requires this when `None` is a possible default value.